### PR TITLE
Event handling for resolution changes and added column and row scaling for grid

### DIFF
--- a/Interfaces.cs
+++ b/Interfaces.cs
@@ -1,12 +1,14 @@
 ﻿using StrategyGame.Managers;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System;
 
 namespace StrategyGame.Screens
 {
     interface IScreen
     {
         void Initialize(ScreenManager screenManager);
+        void Reinitialize(object sender, EventArgs e);
         void Draw(SpriteBatch spriteBatch);
         void Update(GameTime gameTime);
     }

--- a/Managers/GraphicsManager.cs
+++ b/Managers/GraphicsManager.cs
@@ -9,6 +9,13 @@ namespace StrategyGame.Managers
 {
     public static class GraphicsManager
     {
+        public static event EventHandler<EventArgs> ResolutionChanged;
+
+        public static void OnResolutionChanged()
+        {
+            ResolutionChanged?.Invoke(null, EventArgs.Empty);
+        }
+
         private static GraphicsDevice Graphics { get; } = ContentService.Instance.Graphics;
 
         private static GraphicsDeviceManager GraphicsDeviceManager;
@@ -20,7 +27,11 @@ namespace StrategyGame.Managers
 
         internal static void ToggleFullscreen(object sender, EventArgs e)
         {
-            GraphicsDeviceManager.ToggleFullScreen();
+            GraphicsDeviceManager.PreferredBackBufferWidth = Graphics.DisplayMode.Width;
+            GraphicsDeviceManager.PreferredBackBufferHeight = Graphics.DisplayMode.Height;
+            GraphicsDeviceManager.IsFullScreen = true;
+            GraphicsDeviceManager.ApplyChanges();
+            OnResolutionChanged();
         }
 
         internal static void ToggleLowRes(object sender, EventArgs e)
@@ -28,6 +39,7 @@ namespace StrategyGame.Managers
             GraphicsDeviceManager.PreferredBackBufferWidth = 1280;
             GraphicsDeviceManager.PreferredBackBufferHeight = 720;
             GraphicsDeviceManager.ApplyChanges();
+            OnResolutionChanged();
         }
 
         internal static void ToggleHighRes(object sender, EventArgs e)
@@ -35,9 +47,10 @@ namespace StrategyGame.Managers
             GraphicsDeviceManager.PreferredBackBufferWidth = 1920;
             GraphicsDeviceManager.PreferredBackBufferHeight = 1080;
             GraphicsDeviceManager.ApplyChanges();
+            OnResolutionChanged();
         }
 
-        public static Viewport Viewport { get; } = ContentService.Instance.Graphics.Viewport;
+        public static Viewport Viewport { get { return ContentService.Instance.Graphics.Viewport; } }
 
         public static Texture2D GetTextureOfColor(Color color)
         {

--- a/Managers/Settings.cs
+++ b/Managers/Settings.cs
@@ -9,8 +9,8 @@ namespace StrategyGame.Managers
     {
         public static int TileWidth { get; private set; } = 50;
         public static int TileHeight { get; private set; } = 50;
-        public static int GridColumns { get; private set; } = 16;
-        public static int GridRows { get; private set; } = 9;
+        public static int GridColumns { get; private set; } = 30;
+        public static int GridRows { get; private set; } = 15;
         public static int GridWidth { get; } = TileWidth * GridColumns;
         public static int GridHeight { get; } = TileHeight * GridRows;
         public static int BorderWidth { get; private set; } = 1;

--- a/Managers/Settings.cs
+++ b/Managers/Settings.cs
@@ -9,11 +9,13 @@ namespace StrategyGame.Managers
     {
         public static int TileWidth { get; private set; } = 50;
         public static int TileHeight { get; private set; } = 50;
-        public static int GridColumns { get; private set; } = 30;
-        public static int GridRows { get; private set; } = 15;
-        public static int GridWidth { get; } = TileWidth * GridColumns;
-        public static int GridHeight { get; } = TileHeight * GridRows;
+        public static int GridColumns { get; set; } = 30;
+        public static int GridRows { get; set; } = 15;
+        public static int GridWidth { get { return TileWidth * GridColumns; } }
+        public static int GridHeight { get { return TileHeight * GridRows; } }
         public static int BorderWidth { get; private set; } = 1;
+        public static double GridWidthPercent { get; } = 0.78125;
+        public static double GridHeightPercent { get; } = 0.69444;
 
         public static Point GridPosition { get; set; } = new Point(50, 50);
         public static Color TextureColor { get; private set; } = Color.White;

--- a/Screens/GameScreen.cs
+++ b/Screens/GameScreen.cs
@@ -21,6 +21,7 @@ namespace StrategyGame.Screens
         Panel statusPanel;
         Panel rightPanel;
         Panel messagePanel;
+        Panel messageLogPanel;
 
         Button inspectorButton;
         Button mapButton;
@@ -46,8 +47,8 @@ namespace StrategyGame.Screens
             this.screenManager = screenManager;
             Viewport screen = GraphicsManager.Viewport;
             screenElements = new List<GameObject>();
-            int marginX = (int)(screen.Width * 0.02);
-            int marginY = (int)(screen.Height * 0.02);
+            int marginX = (int)(screen.Width * 0.01);
+            int marginY = (int)(screen.Height * 0.01);
 
             // Initialize game area with margin around outer edge of screen
             gameArea = new Panel(new Point(screen.X + marginX, screen.Y + marginY), new Point(screen.Width - (marginX*2), screen.Height - (marginY*2)));
@@ -66,13 +67,14 @@ namespace StrategyGame.Screens
 
             // Initialize Panels
             statusPanel = new Panel(new Point(gameArea.X, gameArea.Y), new Point(grid.Width, grid.Top - gameArea.Y));
-            messagePanel = new Panel(new Point(gameArea.X + 1, grid.Bottom + 10), new Point(grid.Width - 3, gameArea.Height - (grid.Height + statusPanel.Height + 10)));
-            rightPanel = new Panel(new Point(grid.Right, gameArea.Y), new Point(15, gameArea.Height));
+            messagePanel = new Panel(new Point(gameArea.X, grid.Bottom), new Point(grid.Width, gameArea.Height - (grid.Height + statusPanel.Height)));
+            messageLogPanel = new Panel(new Point(messagePanel.X + 1, messagePanel.Y + 25), new Point(messagePanel.Width - 3, messagePanel.Height - 40));
+            rightPanel = new Panel(new Point(grid.Right, gameArea.Y), new Point(25, gameArea.Height));
 
             inspectorPanel = new Panel(new Point(rightPanel.Right, gameArea.Y), new Point(gameArea.Width - (grid.Width + rightPanel.Width), gameArea.Height));
             inspectorWindow = new Panel(new Point(inspectorPanel.X, gridPosition.Y), new Point(350, 300));
             inspectorWindow.SetCustomBorder(3, Color.White);
-            messagePanel.SetCustomBorder(3, Color.White);
+            messageLogPanel.SetCustomBorder(3, Color.White);
 
             // Initialize elements on Status Bar
             Rectangle panel = statusPanel.Bounds;
@@ -104,8 +106,8 @@ namespace StrategyGame.Screens
 
             // Initialize elements on Message Panel
             panel = messagePanel.Bounds;
-            messageTitleLabel = new Label("Message Log:", new Vector2(panel.Left + 20, panel.Y + 10), Fonts.Small, Color.Cyan);
-            messageLogLabel = new Label("This is an example battle log entry", new Vector2(panel.Left + 20, messageTitleLabel.Bottom), Fonts.Small, Color.White);
+            messageTitleLabel = new Label(" Message Log: ", new Vector2(panel.Left + 20, panel.Y + 10), Fonts.Small, Color.Cyan);
+            messageLogLabel = new Label("This is an example battle log entry", new Vector2(panel.Left + 20, messageTitleLabel.Bottom + 10), Fonts.Small, Color.White);
 
             // Draw panels first
             screenElements.Add(statusPanel);
@@ -113,6 +115,7 @@ namespace StrategyGame.Screens
             screenElements.Add(messagePanel);
             screenElements.Add(inspectorPanel);
             screenElements.Add(inspectorWindow);
+            screenElements.Add(messageLogPanel);
 
             // Draw elements next
             screenElements.Add(messageTitleLabel);

--- a/Screens/GameScreen.cs
+++ b/Screens/GameScreen.cs
@@ -6,6 +6,7 @@ using StrategyGame.GUI;
 using StrategyGame.IO;
 using System.Diagnostics;
 using System.Collections.Generic;
+using System;
 
 namespace StrategyGame.Screens
 {
@@ -45,8 +46,13 @@ namespace StrategyGame.Screens
         public void Initialize(ScreenManager screenManager)
         {
             this.screenManager = screenManager;
+
+            // Subscribe to changes in resolution
+            GraphicsManager.ResolutionChanged += Reinitialize;
+
             Viewport screen = GraphicsManager.Viewport;
             screenElements = new List<GameObject>();
+
             int marginX = (int)(screen.Width * 0.01);
             int marginY = (int)(screen.Height * 0.01);
 
@@ -62,6 +68,12 @@ namespace StrategyGame.Screens
             Settings.GridPosition = gridPosition;
 
             // Initialize Grid
+            Settings.GridColumns = (int)Math.Floor((GraphicsManager.Viewport.Width * Settings.GridWidthPercent) / Settings.TileWidth);
+            Settings.GridRows = (int)Math.Floor((GraphicsManager.Viewport.Height * Settings.GridHeightPercent) / Settings.TileHeight);
+
+            if (GraphicsManager.Viewport.Width == 1280)
+                Settings.GridColumns -= 3;
+
             grid = new Grid();
             grid.Initialize(Textures.Empty);
 
@@ -136,6 +148,11 @@ namespace StrategyGame.Screens
 
             screenElements.Add(grid);
 
+            Debug.WriteLine("Screen width: " + GraphicsManager.Viewport.Width);
+            Debug.WriteLine("Game Area width: " + gameArea.Width);
+            Debug.WriteLine("Inspector panel width: " + inspectorPanel.Width);
+            Debug.WriteLine("Right panel width: " + rightPanel.Width);
+
         }
 
         public void Update(GameTime gameTime)
@@ -153,5 +170,9 @@ namespace StrategyGame.Screens
             sb.End();
         }
 
+        public void Reinitialize(object sender, EventArgs e)
+        {
+            Initialize(screenManager);
+        }
     }
 }

--- a/Screens/MenuScreen.cs
+++ b/Screens/MenuScreen.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework.Graphics;
 using StrategyGame.Media;
 using StrategyGame.IO;
 using StrategyGame.Managers;
+using System;
 
 namespace StrategyGame.Screens
 {
@@ -18,6 +19,9 @@ namespace StrategyGame.Screens
         public void Initialize(ScreenManager screenManager)
         {
             this.screenManager = screenManager;
+
+            // Subscribe to changes in resolution
+            GraphicsManager.ResolutionChanged += Reinitialize;
 
             Point screenCenter = GraphicsManager.Viewport.Bounds.Center;
 
@@ -73,6 +77,10 @@ namespace StrategyGame.Screens
             return button;
         }
 
+        public void Reinitialize(object sender, EventArgs e)
+        {
+            Initialize(screenManager);
+        }
     }
 
 }

--- a/Screens/OptionsScreen.cs
+++ b/Screens/OptionsScreen.cs
@@ -27,6 +27,10 @@ namespace StrategyGame.Managers
         public void Initialize(ScreenManager screenManager)
         {
             this.screenManager = screenManager;
+
+            // Subscribe to changes in resolution
+            GraphicsManager.ResolutionChanged += Reinitialize;
+
             optionsMenuButtons = new List<Button>();
             subMenuButtons = new List<Button>();
             inSubmenu = false;
@@ -72,7 +76,6 @@ namespace StrategyGame.Managers
             backButton.Hover = Audio.OnMenuHover;
             backButton.Click = Audio.MenuBack;
         }
-
         private void PreviousScreen(object sender, EventArgs e)
         {
             if (inSubmenu)
@@ -140,7 +143,10 @@ namespace StrategyGame.Managers
             button.Click = Audio.MenuForward;
         }
 
-
+        public void Reinitialize(object sender, EventArgs e)
+        {
+            Initialize(screenManager);
+        }
     }
 
 }

--- a/StrategyGame.cs
+++ b/StrategyGame.cs
@@ -22,8 +22,8 @@ namespace StrategyGame
 
         protected override void Initialize()
         {
-            graphics.PreferredBackBufferWidth = 1280;
-            graphics.PreferredBackBufferHeight = 720;
+            graphics.PreferredBackBufferWidth = 1920;
+            graphics.PreferredBackBufferHeight = 1080;
             graphics.ApplyChanges();
 
             base.Initialize();


### PR DESCRIPTION
The game will now scale to new resolutions mid-game, and will attempt to correctly size the grid to fit suitably on most regular screen sizes at 1280 x 720 and above

Closes https://github.com/ethanacex/TurnBasedStrategy/issues/5#issue-834233676
Closes https://github.com/ethanacex/TurnBasedStrategy/issues/4#issue-832301715